### PR TITLE
Multiple resource protection and arbitrary groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
-| <a name="input_resource_arn"></a> [resource\_arn](#input\_resource\_arn) | The ARN of the resource to be protected. | `string` | n/a | yes |
+| <a name="input_name_resource_arn_map"></a> [name\_resource\_arn\_map](#input\_name\_resource\_arn\_map) | A map of names and ARNs of resources to be protected. The name will be used as the name of the resource in the AWS console. | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider. | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -19,7 +19,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_shield-individual"></a> [shield-individual](#module\_shield-individual) | so1omon563/shield-advanced/aws | 2.0.0 |
+| <a name="module_shield"></a> [shield](#module\_shield) | ../../ | n/a |
 
 ## Resources
 
@@ -38,5 +38,5 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_shield-individual"></a> [shield-individual](#output\_shield-individual) | n/a |
+| <a name="output_shield"></a> [shield](#output\_shield) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -16,16 +16,20 @@ resource "aws_eip" "example" {
   vpc = true
 }
 
-module "shield-individual" {
-  source       = "so1omon563/shield-advanced/aws"
-  version      = "2.0.0" # Replace with appropriate version
-  name         = "example"
-  resource_arn = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
+module "shield" {
+  # source       = "so1omon563/shield-advanced/aws"
+  # version      = "3.0.0" # Replace with appropriate version
+  source = "../../"
+
+  # Pass in the name you wish to use for the resource, and the ARN of the resource to be protected.
+  name_resource_arn_map = {
+    "example_resource" = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
+  }
   tags = {
     example = "true"
   }
 }
 
-output "shield-individual" {
-  value = module.shield-individual
+output "shield" {
+  value = module.shield
 }

--- a/examples/basic_usage_by_arbitrary/README.md
+++ b/examples/basic_usage_by_arbitrary/README.md
@@ -1,0 +1,43 @@
+# Basic usage
+
+Basic usage example can be found in the `main.tf` source file.
+
+Example shows using Default Tags in the provider as well as passing additional tags into the resource.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_shield"></a> [shield](#module\_shield) | ../../ | n/a |
+| <a name="module_shield-arbitrary"></a> [shield-arbitrary](#module\_shield-arbitrary) | ../..//modules/group_by_arbitrary/ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_eip.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_shield"></a> [shield](#output\_shield) | n/a |
+| <a name="output_shield-arbitrary"></a> [shield-arbitrary](#output\_shield-arbitrary) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic_usage_by_arbitrary/main.tf
+++ b/examples/basic_usage_by_arbitrary/main.tf
@@ -1,0 +1,55 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      environment = "dev"
+      terraform   = "true"
+    }
+  }
+}
+
+data "aws_availability_zones" "available" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# Create an Elastic IP address to be protected.
+resource "aws_eip" "example" {
+  #checkov:skip=CKV2_AWS_19:EIP is for example only
+  vpc = true
+}
+
+# Protect the Elastic IP address.
+module "shield" {
+  # source       = "so1omon563/shield-advanced/aws"
+  # version      = "3.0.0" # Replace with appropriate version
+  source = "../../"
+
+  # Pass in the name you wish to use for the resource, and the ARN of the resource to be protected.
+  name_resource_arn_map = {
+    "example_resource_for_group" = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
+  }
+  tags = {
+    example = "true"
+  }
+}
+
+output "shield" {
+  value = module.shield
+}
+
+# Add previously protected resources into group.
+module "shield-arbitrary" {
+  #   source  = "so1omon563/shield-advanced/aws//modules/group_by_arbitrary"
+  #   version = "3.0.0" # Replace with appropriate version
+  source = "../..//modules/group_by_arbitrary/"
+
+  name    = "example-group"
+  members = ["arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"]
+
+  tags = {
+    example = "true"
+  }
+}
+
+output "shield-arbitrary" {
+  value = module.shield-arbitrary
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,3 @@
 locals {
   tags = var.tags
-
-  name = var.name
 }

--- a/modules/group_by_arbitrary/README.md
+++ b/modules/group_by_arbitrary/README.md
@@ -1,0 +1,66 @@
+# AWS Shield Advanced protection for ARBITRARY resources
+
+Creates an AWS Shield Advanced protection group for an arbitrary list supported resources.
+
+These resources can include:
+
+- Cloudfront distribution
+
+- Route 53 Hosted Zone
+
+- Global Accelerator
+
+- Application load balancer
+
+- Classic load balancer
+
+- Elastic IP address
+
+Note that this module will use the same `aggregation` value for all defined resources.
+
+If you wish to select / de-select resources by type, and control the aggregation types, there is a `group_by_resource_type` submodule.
+
+This submodule can be found under the [modules](https://github.com/so1omon563/terraform-aws-shield/tree/main/modules) directory.
+
+Examples for use can be found under the [examples](https://github.com/so1omon563/terraform-aws-shield/tree/main/examples) directory.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Auto-generated technical documentation is created using [`terraform-docs`](https://terraform-docs.io/)
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_shield_protection_group.arbitrary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aggregation"></a> [aggregation](#input\_aggregation) | Defines how AWS Shield combines resource data for the group in order to detect, mitigate, and report events. This will define the aggregation for ALL protected resources in this module. See [Managing AWS Shield Advanced protection groups](https://docs.aws.amazon.com/waf/latest/developerguide/manage-protection-group.html) for more information. | `string` | `"SUM"` | no |
+| <a name="input_members"></a> [members](#input\_members) | List of ARNs of the resources to add to the protection group | `list(string)` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the protection group. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_shield"></a> [shield](#output\_shield) | A map of properties for the created AWS Shield protection. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/group_by_arbitrary/locals.tf
+++ b/modules/group_by_arbitrary/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  tags = var.tags
+}

--- a/modules/group_by_arbitrary/main.tf
+++ b/modules/group_by_arbitrary/main.tf
@@ -1,0 +1,12 @@
+/**
+* Auto-generated technical documentation is created using [`terraform-docs`](https://terraform-docs.io/)
+*/
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22"
+    }
+  }
+}

--- a/modules/group_by_arbitrary/outputs.tf
+++ b/modules/group_by_arbitrary/outputs.tf
@@ -1,0 +1,4 @@
+output "shield" {
+  value       = { for key, value in aws_shield_protection_group.arbitrary : key => value }
+  description = "A map of properties for the created AWS Shield protection."
+}

--- a/modules/group_by_arbitrary/shield.tf
+++ b/modules/group_by_arbitrary/shield.tf
@@ -1,0 +1,8 @@
+resource "aws_shield_protection_group" "arbitrary" {
+  protection_group_id = var.name
+  aggregation         = var.aggregation
+  pattern             = "ARBITRARY"
+  members             = var.members
+
+  tags = local.tags
+}

--- a/modules/group_by_arbitrary/vars.tf
+++ b/modules/group_by_arbitrary/vars.tf
@@ -1,0 +1,29 @@
+variable "members" {
+  type        = list(string)
+  description = "List of ARNs of the resources to add to the protection group"
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the protection group."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider."
+  default     = {}
+}
+
+variable "aggregation" {
+  type        = string
+  description = "Defines how AWS Shield combines resource data for the group in order to detect, mitigate, and report events. This will define the aggregation for ALL protected resources in this module. See [Managing AWS Shield Advanced protection groups](https://docs.aws.amazon.com/waf/latest/developerguide/manage-protection-group.html) for more information."
+  default     = "SUM"
+  validation {
+    condition = contains([
+      "SUM",
+      "MEAN",
+      "MAX",
+    ], var.aggregation)
+    error_message = "Valid values are limited to (SUM,MEAN,MAX)."
+  }
+}

--- a/shield.tf
+++ b/shield.tf
@@ -1,6 +1,7 @@
 resource "aws_shield_protection" "shield" {
-  name         = local.name
-  resource_arn = var.resource_arn
+  for_each     = var.name_resource_arn_map
+  name         = each.key
+  resource_arn = each.value
 
   tags = local.tags
 }

--- a/vars.tf
+++ b/vars.tf
@@ -1,15 +1,11 @@
-variable "name" {
-  type        = string
-  description = "Short, descriptive name of the environment. All resources will be named using this value as a prefix."
+variable "name_resource_arn_map" {
+  type        = map(string)
+  description = "A map of names and ARNs of resources to be protected. The name will be used as the name of the resource in the AWS console."
+  default     = {}
 }
 
 variable "tags" {
   type        = map(string)
   description = "A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider."
   default     = {}
-}
-
-variable "resource_arn" {
-  type        = string
-  description = "The ARN of the resource to be protected."
 }


### PR DESCRIPTION
### Description

Changes so the default takes in a map of resources to protect, instead of only one.

Now can also group by ARBITRARY using the appropriate submodule.

### Issues Resolved

List any existing issues this PR resolves.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] Documentation provided or updated for resources
- [x] Any new functionality includes kitchen-terraform/inspec tests to verify functionality.
- [x] All existing kitchen-terraform/inspec tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/so1omon563/terraform-aws-shield-advanced/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
