### PR TITLE
Add Terraform tests and CI for Shield Advanced

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,27 @@
+name: Terraform
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_EC2_METADATA_DISABLED: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false
+      - run: terraform validate
+      - run: terraform test
+      - run: scripts/tf-test.sh

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -1,0 +1,48 @@
+mock_provider "aws" {}
+
+run "no_resources_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_shield_protection.shield) == 0
+    error_message = "No Shield protections should be planned by default."
+  }
+}
+
+run "single_protection" {
+  command = plan
+
+  variables {
+    name_resource_arn_map = {
+      example = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/example/1234567890abcdef"
+    }
+  }
+
+  assert {
+    condition     = aws_shield_protection.shield["example"].name == "example"
+    error_message = "Shield protection name should use the map key."
+  }
+
+  assert {
+    condition     = aws_shield_protection.shield["example"].resource_arn == "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/example/1234567890abcdef"
+    error_message = "Shield protection resource ARN should use the map value."
+  }
+}
+
+run "protection_tags" {
+  command = plan
+
+  variables {
+    name_resource_arn_map = {
+      example = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/example/1234567890abcdef"
+    }
+    tags = {
+      environment = "test"
+    }
+  }
+
+  assert {
+    condition     = aws_shield_protection.shield["example"].tags.environment == "test"
+    error_message = "Shield protection should include provided tags."
+  }
+}

--- a/test/basic-usage/basic-usage.tf
+++ b/test/basic-usage/basic-usage.tf
@@ -1,4 +1,7 @@
 provider "aws" {
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+
   default_tags {
     tags = {
       environment = "dev"
@@ -7,23 +10,13 @@ provider "aws" {
   }
 }
 
-data "aws_availability_zones" "available" {}
-data "aws_region" "current" {}
-data "aws_caller_identity" "current" {}
-
-# Create an Elastic IP to be protected
-resource "aws_eip" "example" {
-  #checkov:skip=CKV2_AWS_19:EIP is for example only
-  domain = "vpc"
-}
-
-# Protect the EIP
+# Protect an example resource ARN.
 module "shield" {
   source = "../.."
 
   # Pass in the name you wish to use for the resource, and the ARN of the resource to be protected.
   name_resource_arn_map = {
-    "basic_testing_resource" = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
+    "basic_testing_resource" = "arn:aws:ec2:us-east-1:123456789012:eip-allocation/eipalloc-example"
   }
   tags = {
     example = "true"


### PR DESCRIPTION
## Summary
- add native Terraform plan tests for Shield protection behavior
- add a public Terraform CI workflow for fmt, init, validate, root tests, and existing test-directory tests
- make the existing basic-usage fixture plan-only without requiring real AWS credentials

## Verification
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate
- terraform test
- scripts/tf-test.sh